### PR TITLE
arm64: Use correct encoding of Sub for SP

### DIFF
--- a/cranelift/codegen/src/isa/arm64/abi.rs
+++ b/cranelift/codegen/src/isa/arm64/abi.rs
@@ -416,11 +416,12 @@ impl ABIBody<Inst> for ARM64ABIBody {
                     mem: MemArg::label(MemLabel::ConstantData(const_data)),
                     is_reload: None,
                 };
-                let sub_inst = Inst::AluRRR {
+                let sub_inst = Inst::AluRRRExtend {
                     alu_op: ALUOp::Sub64,
                     rd: writable_stack_reg(),
                     rn: stack_reg(),
                     rm: tmp.to_reg(),
+                    extendop: ExtendOp::UXTX,
                 };
                 insts.push(const_inst);
                 insts.push(sub_inst);
@@ -610,11 +611,12 @@ fn adjust_stack(amt: u64, is_sub: bool) -> Vec<Inst> {
                 mem: MemArg::Label(MemLabel::ConstantData(u64_constant(amt))),
                 is_reload: None,
             };
-            let adj = Inst::AluRRR {
+            let adj = Inst::AluRRRExtend {
                 alu_op,
                 rd: writable_stack_reg(),
                 rn: stack_reg(),
                 rm: spilltmp_reg(),
+                extendop: ExtendOp::UXTX,
             };
             vec![const_load, adj]
         }

--- a/cranelift/codegen/src/isa/arm64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/arm64/inst/emit.rs
@@ -353,6 +353,7 @@ impl<O: MachSectionOutput> MachInstEmit<O> for Inst {
                     ALUOp::Lsl32 | ALUOp::Lsl64 => 0b001000,
                     _ => 0b000000,
                 };
+                assert_ne!(writable_stack_reg(), rd);
                 sink.put4(enc_arith_rrr(top11, bit15_10, rd, rn, rm));
             }
             &Inst::AluRRRR {


### PR DESCRIPTION
This was being encoded with xzr as:
    neg xzr, reg

Which meant the stack pointer wasn't actually being updated.

Copyright (c) 2020, Arm Limited.