### PR TITLE
arm64: Remove a redundant two way branch

### DIFF
--- a/cranelift/codegen/src/isa/arm64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/arm64/inst/mod.rs
@@ -1054,7 +1054,11 @@ impl MachInst for Inst {
                 not_taken,
                 kind,
             } => {
-                if taken.as_block_index() == fallthrough {
+                if taken.as_block_index() == fallthrough
+                    && not_taken.as_block_index() == fallthrough
+                {
+                    *self = Inst::Nop;
+                } else if taken.as_block_index() == fallthrough {
                     *self = Inst::CondBrLowered {
                         target: not_taken,
                         kind: kind.invert(),

--- a/cranelift/filetests/filetests/vcode/arm64/condbr.clif
+++ b/cranelift/filetests/filetests/vcode/arm64/condbr.clif
@@ -43,3 +43,23 @@ block2:
 ; nextln: mov sp, fp
 ; nextln: ldp fp, lr, [sp], #16
 ; nextln: ret
+
+function %f(i64, i64) -> i64 {
+block0(v0: i64, v1: i64):
+  v2 = ifcmp v0, v1
+  brif eq v2, block1
+  jump block1
+
+block1:
+  v4 = iconst.i64 1
+  return v4
+}
+
+; check: stp fp, lr, [sp, #-16]!
+; nextln: mov fp, sp
+; nextln: subs xzr, x0, x1
+; check: Block 0:
+; check: movz x0, #1
+; nextln: mov sp, fp
+; nextln: ldp fp, lr, [sp], #16
+; nextln: ret


### PR DESCRIPTION
If both the taken and non-taken branches are the fallthrough block
the branch can be removed.

Copyright (c) 2020, Arm Limited.

---

Note that the condition / compare is still present. Do you think we should try nop that out here or do something different?