### PR TITLE
Baldrdash integration

### DIFF
--- a/cranelift/codegen/src/isa/arm64/abi.rs
+++ b/cranelift/codegen/src/isa/arm64/abi.rs
@@ -70,11 +70,17 @@ fn try_fill_baldrdash_reg(call_conv: isa::CallConv, param: &ir::AbiParam) -> Opt
         match &param.purpose {
             &ir::ArgumentPurpose::VMContext => {
                 // This is SpiderMonkey's `WasmTlsReg`.
-                Some(ABIArg::Reg(xreg(BALDRDASH_TLS_REG).to_real_reg(), ir::types::I64))
+                Some(ABIArg::Reg(
+                    xreg(BALDRDASH_TLS_REG).to_real_reg(),
+                    ir::types::I64,
+                ))
             }
             &ir::ArgumentPurpose::SignatureId => {
                 // This is SpiderMonkey's `WasmTableCallSigReg`.
-                Some(ABIArg::Reg(xreg(BALDRDASH_SIG_REG).to_real_reg(), ir::types::I64))
+                Some(ABIArg::Reg(
+                    xreg(BALDRDASH_SIG_REG).to_real_reg(),
+                    ir::types::I64,
+                ))
             }
             _ => None,
         }
@@ -235,9 +241,21 @@ fn load_stack(fp_offset: i64, into_reg: Writable<Reg>, ty: Type) -> Inst {
         | types::B32
         | types::I32
         | types::B64
-        | types::I64 => Inst::ULoad64 { rd: into_reg, mem, srcloc: None },
-        types::F32 => Inst::FpuLoad32 { rd: into_reg, mem, srcloc: None },
-        types::F64 => Inst::FpuLoad64 { rd: into_reg, mem, srcloc: None },
+        | types::I64 => Inst::ULoad64 {
+            rd: into_reg,
+            mem,
+            srcloc: None,
+        },
+        types::F32 => Inst::FpuLoad32 {
+            rd: into_reg,
+            mem,
+            srcloc: None,
+        },
+        types::F64 => Inst::FpuLoad64 {
+            rd: into_reg,
+            mem,
+            srcloc: None,
+        },
         _ => unimplemented!(),
     }
 }
@@ -254,9 +272,21 @@ fn store_stack(fp_offset: i64, from_reg: Reg, ty: Type) -> Inst {
         | types::B32
         | types::I32
         | types::B64
-        | types::I64 => Inst::Store64 { rd: from_reg, mem, srcloc: None },
-        types::F32 => Inst::FpuStore32 { rd: from_reg, mem, srcloc: None },
-        types::F64 => Inst::FpuStore64 { rd: from_reg, mem, srcloc: None },
+        | types::I64 => Inst::Store64 {
+            rd: from_reg,
+            mem,
+            srcloc: None,
+        },
+        types::F32 => Inst::FpuStore32 {
+            rd: from_reg,
+            mem,
+            srcloc: None,
+        },
+        types::F64 => Inst::FpuStore64 {
+            rd: from_reg,
+            mem,
+            srcloc: None,
+        },
         _ => unimplemented!(),
     }
 }
@@ -533,7 +563,8 @@ impl ABIBody<Inst> for ARM64ABIBody {
         }
 
         // Save clobbered registers.
-        let (clobbered_int, clobbered_vec) = get_callee_saves(self.call_conv, self.clobbered.to_vec());
+        let (clobbered_int, clobbered_vec) =
+            get_callee_saves(self.call_conv, self.clobbered.to_vec());
         for reg_pair in clobbered_int.chunks(2) {
             let (r1, r2) = if reg_pair.len() == 2 {
                 // .to_reg().to_reg(): Writable<RealReg> --> RealReg --> Reg
@@ -580,7 +611,8 @@ impl ABIBody<Inst> for ARM64ABIBody {
         let mut insts = vec![];
 
         // Restore clobbered registers.
-        let (clobbered_int, clobbered_vec) = get_callee_saves(self.call_conv, self.clobbered.to_vec());
+        let (clobbered_int, clobbered_vec) =
+            get_callee_saves(self.call_conv, self.clobbered.to_vec());
 
         for (i, reg) in clobbered_vec.iter().enumerate() {
             insts.push(Inst::FpuLoad128 {

--- a/cranelift/codegen/src/isa/arm64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/arm64/inst/emit.rs
@@ -1012,8 +1012,8 @@ impl<O: MachSectionOutput> MachInstEmit<O> for Inst {
             &Inst::EpiloguePlaceholder {} => {
                 // Noop; this is just a placeholder for epilogues.
             }
-            &Inst::Call { ref dest, .. } => {
-                sink.add_reloc(Reloc::Arm64Call, dest, 0);
+            &Inst::Call { ref dest, loc, .. } => {
+                sink.add_reloc(loc, Reloc::Arm64Call, dest, 0);
                 sink.put4(enc_jump26(0b100101, 0));
             }
             &Inst::CallInd { rn, .. } => {
@@ -1163,6 +1163,7 @@ impl<O: MachSectionOutput> MachInstEmit<O> for Inst {
                 rd,
                 ref name,
                 offset,
+                srcloc,
             } => {
                 let inst = Inst::ULoad64 {
                     rd,
@@ -1173,7 +1174,7 @@ impl<O: MachSectionOutput> MachInstEmit<O> for Inst {
                     dest: BranchTarget::ResolvedOffset(12),
                 };
                 inst.emit(sink);
-                sink.add_reloc(Reloc::Abs8, name, offset);
+                sink.add_reloc(srcloc, Reloc::Abs8, name, offset);
                 sink.put8(0);
             }
         }
@@ -3174,6 +3175,7 @@ mod test {
                 dest: ExternalName::testcase("test0"),
                 uses: Set::empty(),
                 defs: Set::empty(),
+                loc: SourceLoc::default(),
             },
             "00000094",
             "bl 0",
@@ -3184,6 +3186,7 @@ mod test {
                 rn: xreg(10),
                 uses: Set::empty(),
                 defs: Set::empty(),
+                loc: SourceLoc::default(),
             },
             "40013FD6",
             "blr x10",

--- a/cranelift/codegen/src/isa/arm64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/arm64/inst/emit.rs
@@ -2453,7 +2453,7 @@ mod test {
                     xreg(2),
                     UImm12Scaled::maybe_from_i64(32760, I64).unwrap(),
                 ),
-                is_reload: None,
+                srcloc: None,
             },
             "41FC7FF9",
             "ldr x1, [x2, #32760]",
@@ -3791,6 +3791,7 @@ mod test {
             Inst::FpuLoad32 {
                 rd: writable_vreg(16),
                 mem: MemArg::RegScaled(xreg(8), xreg(9), F32),
+                srcloc: None,
             },
             "107969BC",
             "ldr s16, [x8, x9, LSL #2]",
@@ -3800,6 +3801,7 @@ mod test {
             Inst::FpuLoad64 {
                 rd: writable_vreg(16),
                 mem: MemArg::RegScaled(xreg(8), xreg(9), F64),
+                srcloc: None,
             },
             "107969FC",
             "ldr d16, [x8, x9, LSL #3]",
@@ -3809,6 +3811,7 @@ mod test {
             Inst::FpuLoad128 {
                 rd: writable_vreg(16),
                 mem: MemArg::RegScaled(xreg(8), xreg(9), I128),
+                srcloc: None,
             },
             "1079E93C",
             "ldr q16, [x8, x9, LSL #4]",
@@ -3818,6 +3821,7 @@ mod test {
             Inst::FpuLoad32 {
                 rd: writable_vreg(16),
                 mem: MemArg::Label(MemLabel::PCRel(8)),
+                srcloc: None,
             },
             "5000001C",
             "ldr s16, pc+8",
@@ -3827,6 +3831,7 @@ mod test {
             Inst::FpuLoad64 {
                 rd: writable_vreg(16),
                 mem: MemArg::Label(MemLabel::PCRel(8)),
+                srcloc: None,
             },
             "5000005C",
             "ldr d16, pc+8",
@@ -3836,6 +3841,7 @@ mod test {
             Inst::FpuLoad128 {
                 rd: writable_vreg(16),
                 mem: MemArg::Label(MemLabel::PCRel(8)),
+                srcloc: None,
             },
             "5000009C",
             "ldr q16, pc+8",
@@ -3845,6 +3851,7 @@ mod test {
             Inst::FpuStore32 {
                 rd: vreg(16),
                 mem: MemArg::RegScaled(xreg(8), xreg(9), F32),
+                srcloc: None,
             },
             "107929BC",
             "str s16, [x8, x9, LSL #2]",
@@ -3854,6 +3861,7 @@ mod test {
             Inst::FpuStore64 {
                 rd: vreg(16),
                 mem: MemArg::RegScaled(xreg(8), xreg(9), F64),
+                srcloc: None,
             },
             "107929FC",
             "str d16, [x8, x9, LSL #3]",
@@ -3863,6 +3871,7 @@ mod test {
             Inst::FpuStore128 {
                 rd: vreg(16),
                 mem: MemArg::RegScaled(xreg(8), xreg(9), I128),
+                srcloc: None,
             },
             "1079A93C",
             "str q16, [x8, x9, LSL #4]",

--- a/cranelift/codegen/src/isa/arm64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/arm64/inst/mod.rs
@@ -289,57 +289,68 @@ pub enum Inst {
     ULoad8 {
         rd: Writable<Reg>,
         mem: MemArg,
+        srcloc: Option<SourceLoc>,
     },
     /// A signed (sign-extending) 8-bit load.
     SLoad8 {
         rd: Writable<Reg>,
         mem: MemArg,
+        srcloc: Option<SourceLoc>,
     },
     /// An unsigned (zero-extending) 16-bit load.
     ULoad16 {
         rd: Writable<Reg>,
         mem: MemArg,
+        srcloc: Option<SourceLoc>,
     },
     /// A signed (sign-extending) 16-bit load.
     SLoad16 {
         rd: Writable<Reg>,
         mem: MemArg,
+        srcloc: Option<SourceLoc>,
     },
     /// An unsigned (zero-extending) 32-bit load.
     ULoad32 {
         rd: Writable<Reg>,
         mem: MemArg,
+        srcloc: Option<SourceLoc>,
     },
     /// A signed (sign-extending) 32-bit load.
     SLoad32 {
         rd: Writable<Reg>,
         mem: MemArg,
+        srcloc: Option<SourceLoc>,
     },
     /// A 64-bit load.
     ULoad64 {
         rd: Writable<Reg>,
         mem: MemArg,
+        srcloc: Option<SourceLoc>,
     },
 
     /// An 8-bit store.
     Store8 {
         rd: Reg,
         mem: MemArg,
+        srcloc: Option<SourceLoc>,
     },
     /// A 16-bit store.
     Store16 {
         rd: Reg,
         mem: MemArg,
+        srcloc: Option<SourceLoc>,
     },
     /// A 32-bit store.
     Store32 {
         rd: Reg,
         mem: MemArg,
+        srcloc: Option<SourceLoc>,
     },
     /// A 64-bit store.
     Store64 {
         rd: Reg,
         mem: MemArg,
+        srcloc: Option<SourceLoc>,
     },
 
     /// A store of a pair of registers.
@@ -458,26 +469,32 @@ pub enum Inst {
     FpuLoad32 {
         rd: Writable<Reg>,
         mem: MemArg,
+        srcloc: Option<SourceLoc>,
     },
     FpuStore32 {
         rd: Reg,
+        srcloc: Option<SourceLoc>,
         mem: MemArg,
     },
     FpuLoad64 {
         rd: Writable<Reg>,
         mem: MemArg,
+        srcloc: Option<SourceLoc>,
     },
     FpuStore64 {
         rd: Reg,
         mem: MemArg,
+        srcloc: Option<SourceLoc>,
     },
     FpuLoad128 {
         rd: Writable<Reg>,
         mem: MemArg,
+        srcloc: Option<SourceLoc>,
     },
     FpuStore128 {
         rd: Reg,
         mem: MemArg,
+        srcloc: Option<SourceLoc>,
     },
 
     LoadFpuConst32 {
@@ -566,6 +583,7 @@ pub enum Inst {
         uses: Set<Reg>,
         defs: Set<Writable<Reg>>,
         loc: SourceLoc,
+        opcode: Opcode,
     },
     /// A machine indirect-call instruction.
     CallInd {
@@ -573,6 +591,7 @@ pub enum Inst {
         uses: Set<Reg>,
         defs: Set<Writable<Reg>>,
         loc: SourceLoc,
+        opcode: Opcode,
     },
 
     // ---- branches (exactly one must appear at end of BB) ----
@@ -1210,49 +1229,96 @@ fn arm64_map_regs(
             rd: map_wr(d, rd),
             rn: map(u, rn),
         },
-        &mut Inst::ULoad8 { rd, ref mem } => Inst::ULoad8 {
+        &mut Inst::ULoad8 {
+            rd,
+            ref mem,
+            srcloc,
+        } => Inst::ULoad8 {
             rd: map_wr(d, rd),
             mem: map_mem(u, mem),
+            srcloc,
         },
-        &mut Inst::SLoad8 { rd, ref mem } => Inst::SLoad8 {
+        &mut Inst::SLoad8 {
+            rd,
+            ref mem,
+            srcloc,
+        } => Inst::SLoad8 {
             rd: map_wr(d, rd),
             mem: map_mem(u, mem),
+            srcloc,
         },
-        &mut Inst::ULoad16 { rd, ref mem } => Inst::ULoad16 {
+        &mut Inst::ULoad16 {
+            rd,
+            ref mem,
+            srcloc,
+        } => Inst::ULoad16 {
             rd: map_wr(d, rd),
             mem: map_mem(u, mem),
+            srcloc,
         },
-        &mut Inst::SLoad16 { rd, ref mem } => Inst::SLoad16 {
+        &mut Inst::SLoad16 {
+            rd,
+            ref mem,
+            srcloc,
+        } => Inst::SLoad16 {
             rd: map_wr(d, rd),
             mem: map_mem(u, mem),
+            srcloc,
         },
-        &mut Inst::ULoad32 { rd, ref mem } => Inst::ULoad32 {
+        &mut Inst::ULoad32 {
+            rd,
+            ref mem,
+            srcloc,
+        } => Inst::ULoad32 {
             rd: map_wr(d, rd),
             mem: map_mem(u, mem),
+            srcloc,
         },
-        &mut Inst::SLoad32 { rd, ref mem } => Inst::SLoad32 {
+        &mut Inst::SLoad32 {
+            rd,
+            ref mem,
+            srcloc,
+        } => Inst::SLoad32 {
             rd: map_wr(d, rd),
             mem: map_mem(u, mem),
+            srcloc,
         },
-        &mut Inst::ULoad64 { rd, ref mem } => Inst::ULoad64 {
+        &mut Inst::ULoad64 { rd, ref mem, srcloc } => Inst::ULoad64 {
             rd: map_wr(d, rd),
             mem: map_mem(u, mem),
+            srcloc
         },
-        &mut Inst::Store8 { rd, ref mem } => Inst::Store8 {
+        &mut Inst::Store8 {
+            rd,
+            ref mem,
+            srcloc,
+        } => Inst::Store8 {
             rd: map(u, rd),
             mem: map_mem(u, mem),
+            srcloc,
         },
-        &mut Inst::Store16 { rd, ref mem } => Inst::Store16 {
+        &mut Inst::Store16 {
+            rd,
+            ref mem,
+            srcloc,
+        } => Inst::Store16 {
             rd: map(u, rd),
             mem: map_mem(u, mem),
+            srcloc,
         },
-        &mut Inst::Store32 { rd, ref mem } => Inst::Store32 {
+        &mut Inst::Store32 {
+            rd,
+            ref mem,
+            srcloc,
+        } => Inst::Store32 {
             rd: map(u, rd),
             mem: map_mem(u, mem),
+            srcloc,
         },
-        &mut Inst::Store64 { rd, ref mem } => Inst::Store64 {
+        &mut Inst::Store64 { rd, ref mem, srcloc } => Inst::Store64 {
             rd: map(u, rd),
             mem: map_mem(u, mem),
+            srcloc
         },
         &mut Inst::StoreP64 { rt, rt2, ref mem } => Inst::StoreP64 {
             rt: map(u, rt),
@@ -1330,29 +1396,35 @@ fn arm64_map_regs(
             rn: map(u, rn),
             rm: map(u, rm),
         },
-        &mut Inst::FpuLoad32 { rd, ref mem } => Inst::FpuLoad32 {
+        &mut Inst::FpuLoad32 { rd, ref mem, srcloc } => Inst::FpuLoad32 {
             rd: map_wr(d, rd),
             mem: map_mem(u, mem),
+            srcloc
         },
-        &mut Inst::FpuLoad64 { rd, ref mem } => Inst::FpuLoad64 {
+        &mut Inst::FpuLoad64 { rd, ref mem, srcloc } => Inst::FpuLoad64 {
             rd: map_wr(d, rd),
             mem: map_mem(u, mem),
+            srcloc
         },
-        &mut Inst::FpuLoad128 { rd, ref mem } => Inst::FpuLoad64 {
+        &mut Inst::FpuLoad128 { rd, ref mem, srcloc } => Inst::FpuLoad64 {
             rd: map_wr(d, rd),
             mem: map_mem(u, mem),
+            srcloc
         },
-        &mut Inst::FpuStore32 { rd, ref mem } => Inst::FpuStore32 {
+        &mut Inst::FpuStore32 { rd, ref mem, srcloc } => Inst::FpuStore32 {
             rd: map(u, rd),
             mem: map_mem(u, mem),
+            srcloc
         },
-        &mut Inst::FpuStore64 { rd, ref mem } => Inst::FpuStore64 {
+        &mut Inst::FpuStore64 { rd, ref mem, srcloc } => Inst::FpuStore64 {
             rd: map(u, rd),
             mem: map_mem(u, mem),
+            srcloc
         },
-        &mut Inst::FpuStore128 { rd, ref mem } => Inst::FpuStore64 {
+        &mut Inst::FpuStore128 { rd, ref mem, srcloc } => Inst::FpuStore64 {
             rd: map(u, rd),
             mem: map_mem(u, mem),
+            srcloc
         },
         &mut Inst::LoadFpuConst32 { rd, const_data } => Inst::LoadFpuConst32 {
             rd: map_wr(d, rd),
@@ -1428,6 +1500,7 @@ fn arm64_map_regs(
             ref defs,
             ref dest,
             loc,
+            opcode,
         } => {
             let uses = uses.map(|r| map(u, *r));
             let defs = defs.map(|r| map_wr(d, *r));
@@ -1437,6 +1510,7 @@ fn arm64_map_regs(
                 uses,
                 defs,
                 loc,
+                opcode,
             }
         }
         &mut Inst::Ret {} => Inst::Ret {},
@@ -1446,6 +1520,7 @@ fn arm64_map_regs(
             ref defs,
             rn,
             loc,
+            opcode,
         } => {
             let uses = uses.map(|r| map(u, *r));
             let defs = defs.map(|r| map_wr(d, *r));
@@ -1454,6 +1529,7 @@ fn arm64_map_regs(
                 defs,
                 rn: map(u, rn),
                 loc,
+                opcode,
             }
         }
         &mut Inst::CondBr {
@@ -1877,13 +1953,42 @@ impl ShowWithRRU for Inst {
                 let rn = show_ireg_sized(rn, mb_rru, is32);
                 format!("{} {}, {}", op, rd, rn)
             }
-            &Inst::ULoad8 { rd, ref mem }
-            | &Inst::SLoad8 { rd, ref mem }
-            | &Inst::ULoad16 { rd, ref mem }
-            | &Inst::SLoad16 { rd, ref mem }
-            | &Inst::ULoad32 { rd, ref mem }
-            | &Inst::SLoad32 { rd, ref mem }
-            | &Inst::ULoad64 { rd, ref mem, .. } => {
+            &Inst::ULoad8 {
+                rd,
+                ref mem,
+                srcloc: _srcloc,
+            }
+            | &Inst::SLoad8 {
+                rd,
+                ref mem,
+                srcloc: _srcloc,
+            }
+            | &Inst::ULoad16 {
+                rd,
+                ref mem,
+                srcloc: _srcloc,
+            }
+            | &Inst::SLoad16 {
+                rd,
+                ref mem,
+                srcloc: _srcloc,
+            }
+            | &Inst::ULoad32 {
+                rd,
+                ref mem,
+                srcloc: _srcloc,
+            }
+            | &Inst::SLoad32 {
+                rd,
+                ref mem,
+                srcloc: _srcloc,
+            }
+            | &Inst::ULoad64 {
+                rd,
+                ref mem,
+                srcloc: _srcloc,
+                ..
+            } => {
                 let (mem_str, mem) = mem_finalize_for_show(mem, mb_rru);
 
                 let is_unscaled = match &mem {
@@ -1911,10 +2016,27 @@ impl ShowWithRRU for Inst {
                 let mem = mem.show_rru(mb_rru);
                 format!("{}{} {}, {}", mem_str, op, rd, mem)
             }
-            &Inst::Store8 { rd, ref mem }
-            | &Inst::Store16 { rd, ref mem }
-            | &Inst::Store32 { rd, ref mem }
-            | &Inst::Store64 { rd, ref mem, .. } => {
+            &Inst::Store8 {
+                rd,
+                ref mem,
+                srcloc: _srcloc,
+            }
+            | &Inst::Store16 {
+                rd,
+                ref mem,
+                srcloc: _srcloc,
+            }
+            | &Inst::Store32 {
+                rd,
+                ref mem,
+                srcloc: _srcloc,
+            }
+            | &Inst::Store64 {
+                rd,
+                ref mem,
+                srcloc: _srcloc,
+                ..
+            } => {
                 let (mem_str, mem) = mem_finalize_for_show(mem, mb_rru);
 
                 let is_unscaled = match &mem {

--- a/cranelift/codegen/src/isa/arm64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/arm64/inst/mod.rs
@@ -1550,7 +1550,7 @@ impl MachInst for Inst {
 
     fn is_term<'a>(&'a self) -> MachTerminator<'a> {
         match self {
-            &Inst::Ret {} => MachTerminator::Ret,
+            &Inst::Ret {} | &Inst::EpiloguePlaceholder {} => MachTerminator::Ret,
             &Inst::Jump { dest } => MachTerminator::Uncond(dest.as_block_index().unwrap()),
             &Inst::CondBr {
                 taken, not_taken, ..

--- a/cranelift/codegen/src/isa/arm64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/arm64/inst/mod.rs
@@ -643,7 +643,9 @@ pub enum Inst {
 
     /// An instruction guaranteed to always be undefined and to trigger an illegal instruction at
     /// runtime.
-    Udf { trap_info: (SourceLoc, TrapCode) },
+    Udf {
+        trap_info: (SourceLoc, TrapCode),
+    },
 
     /// Load the address (using a PC-relative offset) of a MemLabel, using the
     /// `ADR` instruction.
@@ -1283,10 +1285,14 @@ fn arm64_map_regs(
             mem: map_mem(u, mem),
             srcloc,
         },
-        &mut Inst::ULoad64 { rd, ref mem, srcloc } => Inst::ULoad64 {
+        &mut Inst::ULoad64 {
+            rd,
+            ref mem,
+            srcloc,
+        } => Inst::ULoad64 {
             rd: map_wr(d, rd),
             mem: map_mem(u, mem),
-            srcloc
+            srcloc,
         },
         &mut Inst::Store8 {
             rd,
@@ -1315,10 +1321,14 @@ fn arm64_map_regs(
             mem: map_mem(u, mem),
             srcloc,
         },
-        &mut Inst::Store64 { rd, ref mem, srcloc } => Inst::Store64 {
+        &mut Inst::Store64 {
+            rd,
+            ref mem,
+            srcloc,
+        } => Inst::Store64 {
             rd: map(u, rd),
             mem: map_mem(u, mem),
-            srcloc
+            srcloc,
         },
         &mut Inst::StoreP64 { rt, rt2, ref mem } => Inst::StoreP64 {
             rt: map(u, rt),
@@ -1396,35 +1406,59 @@ fn arm64_map_regs(
             rn: map(u, rn),
             rm: map(u, rm),
         },
-        &mut Inst::FpuLoad32 { rd, ref mem, srcloc } => Inst::FpuLoad32 {
+        &mut Inst::FpuLoad32 {
+            rd,
+            ref mem,
+            srcloc,
+        } => Inst::FpuLoad32 {
             rd: map_wr(d, rd),
             mem: map_mem(u, mem),
-            srcloc
+            srcloc,
         },
-        &mut Inst::FpuLoad64 { rd, ref mem, srcloc } => Inst::FpuLoad64 {
+        &mut Inst::FpuLoad64 {
+            rd,
+            ref mem,
+            srcloc,
+        } => Inst::FpuLoad64 {
             rd: map_wr(d, rd),
             mem: map_mem(u, mem),
-            srcloc
+            srcloc,
         },
-        &mut Inst::FpuLoad128 { rd, ref mem, srcloc } => Inst::FpuLoad64 {
+        &mut Inst::FpuLoad128 {
+            rd,
+            ref mem,
+            srcloc,
+        } => Inst::FpuLoad64 {
             rd: map_wr(d, rd),
             mem: map_mem(u, mem),
-            srcloc
+            srcloc,
         },
-        &mut Inst::FpuStore32 { rd, ref mem, srcloc } => Inst::FpuStore32 {
+        &mut Inst::FpuStore32 {
+            rd,
+            ref mem,
+            srcloc,
+        } => Inst::FpuStore32 {
             rd: map(u, rd),
             mem: map_mem(u, mem),
-            srcloc
+            srcloc,
         },
-        &mut Inst::FpuStore64 { rd, ref mem, srcloc } => Inst::FpuStore64 {
+        &mut Inst::FpuStore64 {
+            rd,
+            ref mem,
+            srcloc,
+        } => Inst::FpuStore64 {
             rd: map(u, rd),
             mem: map_mem(u, mem),
-            srcloc
+            srcloc,
         },
-        &mut Inst::FpuStore128 { rd, ref mem, srcloc } => Inst::FpuStore64 {
+        &mut Inst::FpuStore128 {
+            rd,
+            ref mem,
+            srcloc,
+        } => Inst::FpuStore64 {
             rd: map(u, rd),
             mem: map_mem(u, mem),
-            srcloc
+            srcloc,
         },
         &mut Inst::LoadFpuConst32 { rd, const_data } => Inst::LoadFpuConst32 {
             rd: map_wr(d, rd),

--- a/cranelift/codegen/src/isa/arm64/lower.rs
+++ b/cranelift/codegen/src/isa/arm64/lower.rs
@@ -1711,18 +1711,18 @@ fn lower_insn_to_regs<C: LowerCtx<Inst>>(ctx: &mut C, insn: IRInst) {
                     let extname = ctx.call_target(insn).unwrap();
                     let extname = extname.clone();
                     // HACK: get the function address with an Abs8 reloc in the constant pool.
-                    let tmp = ctx.tmp(RegClass::I64, I64);
-                    ctx.emit(Inst::LoadExtName {
-                        rd: tmp,
-                        name: extname,
-                        srcloc: loc,
-                        offset: 0,
-                    });
+                    //let tmp = ctx.tmp(RegClass::I64, I64);
+                    //ctx.emit(Inst::LoadExtName {
+                    //rd: tmp,
+                    //name: extname,
+                    //srcloc: loc,
+                    //offset: 0,
+                    //});
                     let sig = ctx.call_sig(insn).unwrap();
                     assert!(inputs.len() == sig.params.len());
                     assert!(outputs.len() == sig.returns.len());
-                    // (ARM64ABICall::from_func(sig, extname), &inputs[..])
-                    (ARM64ABICall::from_ptr(sig, tmp.to_reg(), loc), &inputs[..])
+                    (ARM64ABICall::from_func(sig, &extname, loc), &inputs[..])
+                    //(ARM64ABICall::from_ptr(sig, tmp.to_reg(), loc), &inputs[..])
                 }
                 Opcode::CallIndirect => {
                     let ptr = input_to_reg(ctx, inputs[0], NarrowValueMode::ZeroExtend64);

--- a/cranelift/codegen/src/isa/arm64/lower.rs
+++ b/cranelift/codegen/src/isa/arm64/lower.rs
@@ -1371,7 +1371,7 @@ fn lower_insn_to_regs<C: LowerCtx<Inst>>(ctx: &mut C, insn: IRInst) {
             };
 
             ctx.emit(match ty_bits(elem_ty) {
-                1 | 8 => Inst::Store8 { rd, mem, srcloc},
+                1 | 8 => Inst::Store8 { rd, mem, srcloc },
                 16 => Inst::Store16 { rd, mem, srcloc },
                 32 => Inst::Store32 { rd, mem, srcloc },
                 64 => Inst::Store64 { rd, mem, srcloc },

--- a/cranelift/codegen/src/isa/test_utils.rs
+++ b/cranelift/codegen/src/isa/test_utils.rs
@@ -1,6 +1,6 @@
 use crate::binemit::{Addend, CodeOffset, CodeSink, Reloc};
 use crate::ir::Value;
-use crate::ir::{ConstantOffset, ExternalName, Function, JumpTable, SourceLoc, TrapCode};
+use crate::ir::{ConstantOffset, ExternalName, Function, JumpTable, Opcode, SourceLoc, TrapCode};
 use crate::isa::TargetIsa;
 
 use alloc::vec::Vec;
@@ -78,4 +78,6 @@ impl CodeSink for TestCodeSink {
     fn end_codegen(&mut self) {}
 
     fn add_stackmap(&mut self, _val_list: &[Value], _func: &Function, _isa: &dyn TargetIsa) {}
+
+    fn add_call_site(&mut self, _opcode: Opcode, _srcloc: SourceLoc) {}
 }

--- a/cranelift/codegen/src/isa/test_utils.rs
+++ b/cranelift/codegen/src/isa/test_utils.rs
@@ -56,7 +56,13 @@ impl CodeSink for TestCodeSink {
 
     fn reloc_block(&mut self, _rel: Reloc, _block_offset: CodeOffset) {}
 
-    fn reloc_external(&mut self, _: SourceLoc, _rel: Reloc, _name: &ExternalName, _addend: Addend) {
+    fn reloc_external(
+        &mut self,
+        _srcloc: SourceLoc,
+        _rel: Reloc,
+        _name: &ExternalName,
+        _addend: Addend,
+    ) {
     }
 
     fn reloc_constant(&mut self, _rel: Reloc, _constant_offset: ConstantOffset) {}

--- a/cranelift/filetests/filetests/vcode/arm64/call.clif
+++ b/cranelift/filetests/filetests/vcode/arm64/call.clif
@@ -10,8 +10,7 @@ block0(v0: i64):
 
 ; check:  stp fp, lr, [sp, #-16]!
 ; nextln:  mov fp, sp
-; nextln:  ldr x1
-; nextln:  blr x1
+; nextln:  bl 0
 ; nextln:  mov sp, fp
 ; nextln:  ldp fp, lr, [sp], #16
 ; nextln:  ret

--- a/cranelift/filetests/filetests/vcode/arm64/traps.clif
+++ b/cranelift/filetests/filetests/vcode/arm64/traps.clif
@@ -5,7 +5,7 @@ block0:
   trap user0
 }
 
-; check: brk #0
+; check: udf
 
 function %g(i64) {
 block0(v0: i64):
@@ -17,7 +17,7 @@ block0(v0: i64):
 
 ; check: subs xzr, x0, #42
 ; nextln: b.ne 8
-; nextln: brk #0
+; nextln: udf
 
 function %h() {
 block0:


### PR DESCRIPTION
First two commits are extracted from https://github.com/bytecodealliance/wasmtime/pull/1460.

There's a spurious Cargo.lock update that was reappearing all the time, so eventually I committed it.

Two following commits (add support for add_call_site in testing + new-isel support for passing sourceloc) fill in the pieces to support the machinery introduced by the two first commits.

Last commit passes the special VMContext register (called WasmTlsReg in Spidermonkey, on arm64 it's x23) value to callees when it sees it.