### PR TITLE
arm64: Support logical immediates

### DIFF
--- a/cranelift/codegen/src/isa/arm64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/arm64/inst/emit.rs
@@ -1857,7 +1857,66 @@ mod test {
             "lsl x8, x9, #63",
         ));
 
-        // TODO: ImmLogic forms (once logic-immediate encoding/decoding exists).
+        insns.push((
+            Inst::AluRRImmLogic {
+                alu_op: ALUOp::And32,
+                rd: writable_xreg(21),
+                rn: xreg(27),
+                imml: ImmLogic::maybe_from_u64(0x80003fff, I32).unwrap(),
+            },
+            "753B0112",
+            "and w21, w27, #2147500031",
+        ));
+        insns.push((
+            Inst::AluRRImmLogic {
+                alu_op: ALUOp::And64,
+                rd: writable_xreg(7),
+                rn: xreg(6),
+                imml: ImmLogic::maybe_from_u64(0x3fff80003fff800, I64).unwrap(),
+            },
+            "C7381592",
+            "and x7, x6, #288221580125796352",
+        ));
+        insns.push((
+            Inst::AluRRImmLogic {
+                alu_op: ALUOp::Orr32,
+                rd: writable_xreg(1),
+                rn: xreg(5),
+                imml: ImmLogic::maybe_from_u64(0x100000, I32).unwrap(),
+            },
+            "A1000C32",
+            "orr w1, w5, #1048576",
+        ));
+        insns.push((
+            Inst::AluRRImmLogic {
+                alu_op: ALUOp::Orr64,
+                rd: writable_xreg(4),
+                rn: xreg(5),
+                imml: ImmLogic::maybe_from_u64(0x8181818181818181, I64).unwrap(),
+            },
+            "A4C401B2",
+            "orr x4, x5, #9331882296111890817",
+        ));
+        insns.push((
+            Inst::AluRRImmLogic {
+                alu_op: ALUOp::Eor32,
+                rd: writable_xreg(1),
+                rn: xreg(5),
+                imml: ImmLogic::maybe_from_u64(0x00007fff, I32).unwrap(),
+            },
+            "A1380052",
+            "eor w1, w5, #32767",
+        ));
+        insns.push((
+            Inst::AluRRImmLogic {
+                alu_op: ALUOp::Eor64,
+                rd: writable_xreg(10),
+                rn: xreg(8),
+                imml: ImmLogic::maybe_from_u64(0x8181818181818181, I64).unwrap(),
+            },
+            "0AC501D2",
+            "eor x10, x8, #9331882296111890817",
+        ));
 
         insns.push((
             Inst::BitRR {

--- a/cranelift/codegen/src/isa/arm64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/arm64/inst/mod.rs
@@ -445,7 +445,7 @@ impl Inst {
         } else if let Some(imm) = MoveWideConst::maybe_from_u64(!value) {
             // 16-bit immediate (shifted by 0, 16, 32 or 48 bits) in MOVN
             smallvec![Inst::MovN { rd, imm }]
-        } else if let Some(imml) = ImmLogic::maybe_from_u64(value) {
+        } else if let Some(imml) = ImmLogic::maybe_from_u64(value, I64) {
             // Weird logical-instruction immediate in ORI using zero register
             smallvec![Inst::AluRRImmLogic {
                 alu_op: ALUOp::Orr64,

--- a/cranelift/codegen/src/isa/arm64/lower.rs
+++ b/cranelift/codegen/src/isa/arm64/lower.rs
@@ -454,7 +454,7 @@ fn input_to_rs_immlogic<C: LowerCtx<Inst>>(
 ) -> ResultRSImmLogic {
     if let InsnInputSource::Output(out) = input_source(ctx, input) {
         if let Some(imm_value) = output_to_const(ctx, out) {
-            if let Some(i) = ImmLogic::maybe_from_u64(imm_value) {
+            if let Some(i) = ImmLogic::maybe_from_u64(imm_value, I64) {
                 ctx.merged(out.insn);
                 return ResultRSImmLogic::ImmLogic(i);
             }


### PR DESCRIPTION
This is a port of VIXL's Assembler::IsImmLogical.

Arm has the original copyright on the VIXL code this was ported from
and is relicensing it under Apache 2 for Cranelift.

Copyright (c) 2020, Arm Limited.

The test to check that all logical immediates can be inverted, is a bit complex since it needs the `get_logical_imm` function. I think it's worth keeping though.