### PR TITLE
Implement pinned register usage

### DIFF
--- a/cranelift/codegen/src/isa/arm64/lower.rs
+++ b/cranelift/codegen/src/isa/arm64/lower.rs
@@ -1899,9 +1899,16 @@ fn lower_insn_to_regs<C: LowerCtx<Inst>>(ctx: &mut C, insn: IRInst) {
             }
         }
 
-        Opcode::GetPinnedReg
-        | Opcode::SetPinnedReg
-        | Opcode::Spill
+        Opcode::GetPinnedReg => {
+            let rd = output_to_reg(ctx, outputs[0]);
+            ctx.emit(Inst::GetPinnedReg { rd });
+        }
+        Opcode::SetPinnedReg => {
+            let rd = input_to_reg(ctx, inputs[0], NarrowValueMode::None);
+            ctx.emit(Inst::SetPinnedReg { rd });
+        }
+
+        Opcode::Spill
         | Opcode::Fill
         | Opcode::FillNop
         | Opcode::Regmove

--- a/cranelift/codegen/src/isa/x64/inst.rs
+++ b/cranelift/codegen/src/isa/x64/inst.rs
@@ -10,7 +10,7 @@ use crate::binemit::{Addend, CodeOffset, CodeSink, Reloc};
 use crate::ir::types::{B1, B128, B16, B32, B64, B8, F32, F64, I128, I16, I32, I64, I8};
 use crate::ir::{ConstantOffset, ExternalName, Function, JumpTable, SourceLoc, TrapCode};
 use crate::ir::{FuncRef, GlobalValue, Type, Value};
-use crate::isa::TargetIsa;
+use crate::isa::{CallConv, TargetIsa};
 use crate::machinst::*;
 
 use regalloc::Map as RegallocMap;
@@ -287,7 +287,7 @@ pub fn reg_RBP() -> Reg {
 }
 
 /// Create the register universe for X64.
-pub fn create_reg_universe() -> RealRegUniverse {
+pub fn create_reg_universe(_call_conv: CallConv) -> RealRegUniverse {
     let mut regs = Vec::<(RealReg, String)>::new();
     let mut allocable_by_class = [None; NUM_REG_CLASSES];
 
@@ -2563,8 +2563,8 @@ impl MachInst for Inst {
         }
     }
 
-    fn reg_universe() -> RealRegUniverse {
-        create_reg_universe()
+    fn reg_universe(call_conv: CallConv) -> RealRegUniverse {
+        create_reg_universe(call_conv)
     }
 }
 
@@ -4687,7 +4687,7 @@ fn test_x64_insn_encoding_and_printing() {
 
     // ========================================================
     // Actually run the tests!
-    let rru = create_reg_universe();
+    let rru = create_reg_universe(CallConv::Fast);
     for (insn, expected_encoding, expected_printing) in insns {
         println!("     {}", insn.show_rru(Some(&rru)));
         // Check the printed text is as expected.

--- a/cranelift/codegen/src/isa/x64/mod.rs
+++ b/cranelift/codegen/src/isa/x64/mod.rs
@@ -4,7 +4,7 @@
 
 use crate::ir::Function;
 use crate::isa::Builder as IsaBuilder;
-use crate::isa::TargetIsa;
+use crate::isa::{CallConv, TargetIsa};
 use crate::machinst::vcode::show_vcode;
 use crate::machinst::{compile, MachBackend, MachCompileResult, TargetIsaAdapter, VCode};
 use crate::result::CodegenResult;
@@ -58,12 +58,18 @@ impl MachBackend for X64Backend {
         func: Function,
         want_disasm: bool,
     ) -> CodegenResult<MachCompileResult> {
+        let call_conv = func.signature.call_conv;
+
         let vcode = self.compile_vcode(func);
         let sections = vcode.emit();
         let frame_size = vcode.frame_size();
 
         let disasm = if want_disasm {
-            Some(show_vcode(&vcode, Some(&create_reg_universe()), &None))
+            Some(show_vcode(
+                &vcode,
+                Some(&create_reg_universe(call_conv)),
+                &None,
+            ))
         } else {
             None
         };
@@ -87,8 +93,8 @@ impl MachBackend for X64Backend {
         FromStr::from_str("x86_64").unwrap()
     }
 
-    fn reg_universe(&self) -> RealRegUniverse {
-        create_reg_universe()
+    fn reg_universe(&self, call_conv: CallConv) -> RealRegUniverse {
+        create_reg_universe(call_conv)
     }
 }
 

--- a/cranelift/codegen/src/machinst/compile.rs
+++ b/cranelift/codegen/src/machinst/compile.rs
@@ -20,10 +20,12 @@ pub fn compile<B: LowerBackend>(
 where
     B::MInst: ShowWithRRU,
 {
+    let call_conv = f.signature.call_conv;
+
     // This lowers the CL IR.
     let mut vcode = Lower::new(f, abi).lower(b);
 
-    let universe = &B::MInst::reg_universe();
+    let universe = &B::MInst::reg_universe(call_conv);
 
     debug!(
         "vcode from lowering: \n{}",

--- a/cranelift/codegen/src/machinst/mod.rs
+++ b/cranelift/codegen/src/machinst/mod.rs
@@ -103,20 +103,22 @@ use crate::entity::SecondaryMap;
 use crate::ir::condcodes::IntCC;
 use crate::ir::ValueLocations;
 use crate::ir::{DataFlowGraph, Function, Inst, Opcode, Type, Value};
-use crate::isa::RegUnit;
+use crate::isa::{CallConv, RegUnit};
 use crate::result::CodegenResult;
 use crate::settings::Flags;
 use crate::HashMap;
+
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::fmt::Debug;
 use core::iter::Sum;
+use std::hash::Hash;
+use std::string::String;
+
 use regalloc::Map as RegallocMap;
 use regalloc::RegUsageCollector;
 use regalloc::{RealReg, RealRegUniverse, Reg, RegClass, SpillSlot, VirtualReg, Writable};
 use smallvec::SmallVec;
-use std::hash::Hash;
-use std::string::String;
 use target_lexicon::Triple;
 
 pub mod lower;
@@ -197,7 +199,7 @@ pub trait MachInst: Clone + Debug {
     fn with_block_offsets(&mut self, my_offset: CodeOffset, targets: &[CodeOffset]);
 
     /// Get the register universe for this backend.
-    fn reg_universe() -> RealRegUniverse;
+    fn reg_universe(call_conv: CallConv) -> RealRegUniverse;
 
     /// Align a basic block offset (from start of function).  By default, no
     /// alignment occurs.
@@ -272,7 +274,7 @@ pub trait MachBackend {
     fn name(&self) -> &'static str;
 
     /// Return the register universe for this backend.
-    fn reg_universe(&self) -> RealRegUniverse;
+    fn reg_universe(&self, call_conv: CallConv) -> RealRegUniverse;
 
     /// Machine-specific condcode info needed by TargetIsa.
     fn unsigned_add_overflow_condition(&self) -> IntCC {


### PR DESCRIPTION
@cfallin I had a question about this: what do you think is the best way to pass settings (`settings::Flags`) around? In this case, we'd probably want to pass them to all the transitive callers of `create_reg_universe`, so this can be pretty invasive...

I had another use for them in codegen too, as another example: Spidermonkey expects unpatched immediates to be all ones, and not all zeroes, for verification purposes.